### PR TITLE
fix: japanese translation for 'Terms of Use'

### DIFF
--- a/src/modules/i18n/files/ja.json
+++ b/src/modules/i18n/files/ja.json
@@ -47,6 +47,6 @@
   "widget.blocked-countries": "アルジェリア、バングラデシュ、ボリビア、ベラルーシ、ブルンジ、ビルマ、コートジボワール（アイボリーコースト）、クリミアとセバストポール、キューバ、コンゴ民主共和国、エクアドル、イラン、イラク、リビア、マリ、モロッコ、リベリア、北朝鮮、ネパール 、ソマリア、スーダン、シリア、ベネズエラ、ジンバブエ、米国。",
   "widget.stake-btc-earn-rewards": "BTCをステークしてリワードを受け取る",
   "widget.swap-error-title": "予期せぬエラーが発生しました。",
-  "widget.terms-of-use-warning": "[スワップ]をクリックすることで、{termsOfUse}、に同意するものとします。",
+  "widget.terms-of-use-warning": "スワップをクリックすることで{termsOfUse}に同意するものとします。",
   "widget.terms-of-use-warning.link": "利用規約"
 }


### PR DESCRIPTION
Make the line in 1 row. 

Before
![image](https://user-images.githubusercontent.com/42575132/111763266-e15bbb00-88dc-11eb-915f-70a806156434.png)


After
![image](https://user-images.githubusercontent.com/42575132/111763194-cbe69100-88dc-11eb-92ee-8a56fbf71fc4.png)
