### PR TITLE
fix: shows maximum 4 decimals as estimated receiving amount

### DIFF
--- a/src/components/CoinAmount/index.tsx
+++ b/src/components/CoinAmount/index.tsx
@@ -1,5 +1,5 @@
 import { Loading, Testable, TextInput, useBuildTestId } from '@swingby-protocol/pulsar';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { Big } from 'big.js';
 import { useEffect, useMemo, useState } from 'react';
@@ -149,7 +149,7 @@ export const CoinAmount = ({ variant, resource, 'data-testid': testId }: Props) 
           <Loading data-testid={buildTestId('amount-to.loading')} />
         ) : isAmountReceivingValid ? (
           <>
-            {Number(Number(amountReceiving).toFixed(4))}
+            <FormattedNumber value={Number(amountReceiving)} maximumFractionDigits={4} />
             <EstLabel>
               <FormattedMessage id="widget.amount-receiving-estimation-label" />
             </EstLabel>


### PR DESCRIPTION

=before=
![image](https://user-images.githubusercontent.com/42575132/115661800-9b2cc800-a370-11eb-973b-e936bbfa21b0.png)

=after=
![image](https://user-images.githubusercontent.com/42575132/115661854-b3044c00-a370-11eb-8b04-9e6ce3f112c2.png)
