### PR TITLE
(Bug) - #107 Update the wording of the icons

### DIFF
--- a/src/components/CoinAmount/coin-map.tsx
+++ b/src/components/CoinAmount/coin-map.tsx
@@ -32,10 +32,10 @@ export const swingbyTextDisplay = (coin: SkybridgeCoin): string => {
       return 'WBTC';
     }
     case 'sbBTC': {
-      return 'sbBTC (Legacy)'
+      return 'sbBTC (Legacy)';
     }
     case 'sbBTC.SKYPOOL': {
-      return 'sbBTC'
+      return 'sbBTC';
     }
     default: {
       return coin;


### PR DESCRIPTION
Closes #107 

## Description
- Updates the wording of the widget from this:
![image](https://user-images.githubusercontent.com/21086218/170453222-c580f55b-926c-4abf-b1cb-daee5eb1741f.png)

To this:
![image](https://user-images.githubusercontent.com/21086218/170453232-d238476f-870d-42b0-82ec-bcb3f2229e3d.png)
